### PR TITLE
typing: add a GroupIdField type

### DIFF
--- a/smp/enumeration_management.py
+++ b/smp/enumeration_management.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 from enum import IntEnum, unique
-from typing import Tuple
+from typing import Annotated, Tuple
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import smp.error as smperr
 import smp.header as smphdr
 import smp.message as smpmsg
+
+GroupIdField = Annotated[
+    smphdr.GroupId | smphdr.UserGroupId | int, Field(union_mode="left_to_right")
+]
 
 
 class GroupCountRequest(smpmsg.ReadRequest):
@@ -41,7 +45,7 @@ class ListOfGroupsResponse(smpmsg.ReadResponse):
     _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT
     _COMMAND_ID = smphdr.CommandId.EnumManagement.LIST_OF_GROUPS
 
-    groups: Tuple[int, ...]
+    groups: Tuple[GroupIdField, ...]
 
 
 class GroupIdRequest(smpmsg.ReadRequest):
@@ -59,7 +63,7 @@ class GroupIdResponse(smpmsg.ReadResponse):
     _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT
     _COMMAND_ID = smphdr.CommandId.EnumManagement.GROUP_ID
 
-    group: int
+    group: GroupIdField
     end: bool | None = None
 
 
@@ -69,7 +73,7 @@ class GroupDetailsRequest(smpmsg.ReadRequest):
     _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT
     _COMMAND_ID = smphdr.CommandId.EnumManagement.GROUP_DETAILS
 
-    groups: Tuple[int, ...]
+    groups: Tuple[GroupIdField, ...]
 
 
 class GroupDetails(BaseModel):
@@ -77,7 +81,7 @@ class GroupDetails(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    id: int
+    id: GroupIdField
     name: str | None = None
     handlers: int | None = None
 

--- a/tests/test_enumeration_management.py
+++ b/tests/test_enumeration_management.py
@@ -77,9 +77,21 @@ def test_ListOfGroupsResponse() -> None:
         smpenum.ListOfGroupsResponse,
         smphdr.OP.READ_RSP,
         smphdr.CommandId.EnumManagement.LIST_OF_GROUPS,
-        {"groups": (2, 5, 15)},
+        {"groups": (2, smphdr.GroupId.RUNTIME_TESTS, 15, 64)},
     )
-    assert r.groups == (2, 5, 15)
+    assert r.groups == (2, 5, 15, 64)
+
+    assert type(r.groups[0]) is smphdr.GroupId
+    assert r.groups[0] == smphdr.GroupId.STATISTICS_MANAGEMENT
+
+    assert type(r.groups[1]) is smphdr.GroupId
+    assert r.groups[1] == smphdr.GroupId.RUNTIME_TESTS
+
+    assert type(r.groups[2]) is int
+    assert r.groups[2] == 15
+
+    assert type(r.groups[3]) is smphdr.UserGroupId
+    assert r.groups[3] == smphdr.UserGroupId.INTERCREATE
 
 
 @pytest.mark.parametrize("index", [0, 1, None])
@@ -99,7 +111,8 @@ def test_GroupIdResponse() -> None:
         smphdr.CommandId.EnumManagement.GROUP_ID,
         {"group": 2},
     )
-    assert r.group == 2
+    assert r.group == smphdr.GroupId.STATISTICS_MANAGEMENT
+    assert type(r.group) is smphdr.GroupId
     assert not r.end
 
 
@@ -108,7 +121,7 @@ def test_GroupDetailsRequest() -> None:
         smpenum.GroupDetailsRequest,
         smphdr.OP.READ,
         smphdr.CommandId.EnumManagement.GROUP_DETAILS,
-        {"groups": (2, 5, 15)},
+        {"groups": (smphdr.GroupId.STATISTICS_MANAGEMENT, smphdr.GroupId.RUNTIME_TESTS, 15)},
     )
 
 
@@ -122,6 +135,7 @@ def test_GroupDetailsResponse() -> None:
                 {"id": 2, "name": "group2", "handlers": 2},
                 {"id": 5, "name": "group5", "handlers": 5},
                 {"id": 15, "name": "group15", "handlers": 15},
+                {"id": 64, "name": "group64", "handlers": 64},
             )
         },
         nested_model=smpenum.GroupDetails,
@@ -130,4 +144,9 @@ def test_GroupDetailsResponse() -> None:
         smpenum.GroupDetails(id=2, name="group2", handlers=2),
         smpenum.GroupDetails(id=5, name="group5", handlers=5),
         smpenum.GroupDetails(id=15, name="group15", handlers=15),
+        smpenum.GroupDetails(id=64, name="group64", handlers=64),
     )
+    assert type(r.groups[0].id) is smphdr.GroupId
+    assert type(r.groups[1].id) is smphdr.GroupId
+    assert type(r.groups[2].id) is int
+    assert type(r.groups[3].id) is smphdr.UserGroupId


### PR DESCRIPTION
An example proof of concept for the "eager type narrowing" of Group IDs.

Printed results look good:
```
(GroupDetails(id=<GroupId.STATISTICS_MANAGEMENT: 2>, name='group2', handlers=2), GroupDetails(id=<GroupId.RUNTIME_TESTS: 5>, name='group5', handlers=5), GroupDetails(id=15, name='group15', handlers=15))
```